### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,18 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
-          architecture: x64
-
-      - name: Install bundler and dependencies
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
+          ruby-version: '2.6'
+          bundler-cache: true
 
       - name: Check build
         run: bundle exec jekyll build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   jekyll (~> 3.1.6)
 
 BUNDLED WITH
-   1.16.1
+   2.3.18

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,12 @@ url: "https://o0Ignition0o.github.io" # The blog url you want to choose (you can
 logo: "https://www.rust-lang.org/logos/rust-logo-64x64-blk.png" # This one is used as blog logo
 twitter_username: o0ignition0o # Your twitter handle
 github_username: o0Ignition0o # Your github handle
+exclude:
+  - vendor
+  - .github
+  - README.md
+  - Gemfile
+  - Gemfile.lock
 
 # Build settings
 highlighter: rouge


### PR DESCRIPTION
- Update actions/checkout to v3
- Replace actions/setup-ruby with ruby/setup-ruby as the former is deprecated

Signed-off-by: Yuki Okushi <jtitor@2k36.org>