### PR TITLE
Update Ruby to 2.7.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
           bundler-cache: true
 
       - name: Check build


### PR DESCRIPTION
Update Ruby from 2.6.x to 2.7.x as 2.6 has reached EoL.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>